### PR TITLE
remove references to smart and normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Additional pandoc options can be provided in the Jekyll `_config.yml`:
 ```
 pandoc:
   extensions:
-    - normalize
-    - smart
     - mathjax
     - csl: _styles/apa.csl
     - bibliography: bibliography/references.bib


### PR DESCRIPTION
these were dropped with more recent versions of pandoc 2.0+. #11 is related